### PR TITLE
Refactor controllers to replace `_model` with `model` getter

### DIFF
--- a/src/auth/controller.js
+++ b/src/auth/controller.js
@@ -11,7 +11,7 @@ class AuthController extends UserController {
         this._accessPolicies.admin.removeAll();
         this._accessPolicies.user.removeAll();
         this._accessPolicies.guest.setCreate(
-            this._model._fields.filter(field => !['isVerified', 'profilePicture', 'creationAt'].includes(field))
+            this.model._fields.filter(field => !['isVerified', 'profilePicture', 'creationAt'].includes(field))
         );
 
         this._validationRulesForLogin = this._validationRules.filter(rule => {
@@ -25,6 +25,13 @@ class AuthController extends UserController {
         this._validationRulesForPasswordResetConfirm = this._validationRules.filter(rule => {
             return ['password', 'password_confirm'].includes(rule.builder.fields[0])
         });
+    }
+
+    /**
+     * @returns {UserModel}
+     */
+    get model() {
+        return super.model;
     }
 
     /**
@@ -76,7 +83,7 @@ class AuthController extends UserController {
         try {
             try {
                 const decoded = jwt.verify(req.params.token, process.env.APP_SECRET);
-                const user = await this._model.getByEmail(decoded.userEmail);
+                const user = await this.model.getByEmail(decoded.userEmail);
 
                 if (!user) {
                     return this._returnNotFound(res);
@@ -124,7 +131,7 @@ class AuthController extends UserController {
             const validationErrors = [];
             const fields = this._prepareFields(req);
 
-            const user = await this._model.getByEmail(fields.email);
+            const user = await this.model.getByEmail(fields.email);
             let passwordIsValid = false;
 
             if (user) {
@@ -157,7 +164,7 @@ class AuthController extends UserController {
                 );
             }
 
-            const accessToken = await this._model.createToken({
+            const accessToken = await this.model.createToken({
                 id: user.id,
                 email: user.email,
                 role: user.role
@@ -193,13 +200,13 @@ class AuthController extends UserController {
     async passwordReset(req, res, next) {
         try {
             const fields = this._prepareFields(req);
-            const user = await this._model.getByEmail(fields.email);
+            const user = await this.model.getByEmail(fields.email);
 
             if (!user) {
                 return this._returnNotFound(res);
             }
 
-            user.passwordResetToken = await this._model.createToken({ userEmail: user.email });
+            user.passwordResetToken = await this.model.createToken({ userEmail: user.email });
             await user.save();
 
             await mailer.sendPasswordReset(
@@ -241,13 +248,13 @@ class AuthController extends UserController {
         try {
             try {
                 const tokenData = jwt.verify(req.params.token, process.env.APP_SECRET);
-                const user = await this._model.getByEmail(tokenData.userEmail);
+                const user = await this.model.getByEmail(tokenData.userEmail);
 
                 if (!user) {
                     return this._returnNotFound(res);
                 }
 
-                user.password = await this._model.createPassword(req.body.password);
+                user.password = await this.model.createPassword(req.body.password);
                 user.passwordResetToken = null;
                 await user.save();
 

--- a/src/calendar/controller.js
+++ b/src/calendar/controller.js
@@ -41,14 +41,21 @@ class CalendarController extends Controller {
             .setCreate(allowedFields)
             .setRead()
             .setUpdate(allowedFields, [{
-                field: this._model._creationByRelationFieldName, operator: '=', value: null
+                field: this.model._creationByRelationFieldName, operator: '=', value: null
             }])
             .setDelete(allowedFields, [{
-                field: this._model._creationByRelationFieldName, operator: '=', value: null
+                field: this.model._creationByRelationFieldName, operator: '=', value: null
             }]);
 
         this._accessPolicies.guest
             .removeAll();
+    }
+
+    /**
+     * @returns {CalendarModel}
+     */
+    get model() {
+        return super.model;
     }
 
     /**
@@ -70,7 +77,7 @@ class CalendarController extends Controller {
                 )
             ];
 
-            const entities = await this._model.getEntities(
+            const entities = await this.model.getEntities(
                 req?.accessOperation?.fields,
                 filters
             );
@@ -125,17 +132,17 @@ class CalendarController extends Controller {
         try {
             const fields = this._prepareFields(req);
 
-            if (this._model._fields.includes(this._model._creationByRelationFieldName)) {
-                fields[this._model._creationByRelationFieldName] = req.user.id;
+            if (this.model._fields.includes(this.model._creationByRelationFieldName)) {
+                fields[this.model._creationByRelationFieldName] = req.user.id;
             }
 
-            let entity = this._model.createEntity(fields);
+            let entity = this.model.createEntity(fields);
             await entity.save();
 
             const calendarUserModel = new CalendarUserModel();
             await calendarUserModel.syncCalendarParticipants(entity.id, this._prepareParticipants(req));
 
-            const calendar = await this._model.getEntityById(entity.id);
+            const calendar = await this.model.getEntityById(entity.id);
             const participants = await calendarUserModel.getCalendarsByCalendarId(calendar.id);
 
             for (const participant of participants) {
@@ -191,7 +198,7 @@ class CalendarController extends Controller {
             const calendarUserModel = new CalendarUserModel();
             await calendarUserModel.syncCalendarParticipants(entity.id, this._prepareParticipants(req));
 
-            const calendar = await this._model.getEntityById(entity.id);
+            const calendar = await this.model.getEntityById(entity.id);
             const participants = await calendarUserModel.getCalendarsByCalendarId(calendar.id);
 
             for (const participant of participants) {
@@ -271,7 +278,7 @@ class CalendarController extends Controller {
                 );
             }
 
-            const calendar = await this._model.getEntityById(req.params.id);
+            const calendar = await this.model.getEntityById(req.params.id);
 
             if (!calendar) {
                 return this._returnNotFound(res);

--- a/src/event/controller.js
+++ b/src/event/controller.js
@@ -69,14 +69,21 @@ class EventController extends Controller {
             .setCreate(allowedFields)
             .setRead()
             .setUpdate(allowedFields.filter(field => field !== 'calendarId'), [{
-                field: this._model._creationByRelationFieldName, operator: '=', value: null
+                field: this.model._creationByRelationFieldName, operator: '=', value: null
             }])
             .setDelete(allowedFields, [{
-                field: this._model._creationByRelationFieldName, operator: '=', value: null
+                field: this.model._creationByRelationFieldName, operator: '=', value: null
             }]);
 
         this._accessPolicies.guest
             .removeAll();
+    }
+
+    /**
+     * @returns {EventModel}
+     */
+    get model() {
+        return super.model;
     }
 
     /**
@@ -147,16 +154,16 @@ class EventController extends Controller {
             Если в isMain = FALSE, то только в общий.
             * */
 
-            if (this._model._fields.includes(this._model._creationByRelationFieldName)) {
-                fields[this._model._creationByRelationFieldName] = req.user.id;
+            if (this.model._fields.includes(this.model._creationByRelationFieldName)) {
+                fields[this.model._creationByRelationFieldName] = req.user.id;
             }
 
-            let entity = this._model.createEntity(fields);
+            let entity = this.model.createEntity(fields);
             await entity.save();
 
-            await this._model.syncEventParticipants(entity.id, this._prepareParticipants(req));
+            await this.model.syncEventParticipants(entity.id, this._prepareParticipants(req));
 
-            const event = await this._model.getEntityById(entity.id);
+            const event = await this.model.getEntityById(entity.id);
             await event.prepareRelationFields();
 
             if (req.calendar.isMain()) {
@@ -190,9 +197,9 @@ class EventController extends Controller {
             Object.assign(entity, this._prepareFields(req));
             await entity.save();
 
-            await this._model.syncEventParticipants(entity.id, this._prepareParticipants(req));
+            await this.model.syncEventParticipants(entity.id, this._prepareParticipants(req));
 
-            const event = await this._model.getEntityById(entity.id);
+            const event = await this.model.getEntityById(entity.id);
             await event.prepareRelationFields();
 
             await this._notifyParticipants(event);
@@ -221,7 +228,7 @@ class EventController extends Controller {
                 return this._returnResponse(res, 400, {}, "Invalid command.");
             }
 
-            const event = await this._model.getEntityById(req.params.id);
+            const event = await this.model.getEntityById(req.params.id);
 
             if (!event) {
                 return this._returnNotFound(res);


### PR DESCRIPTION
Replaced direct access to `_model` with a `model` getter across all controllers for better encapsulation and consistency. Modified private model property to `#model` and added necessary getter methods to maintain functionality. Ensured all model-related operations now flow through the getter where applicable.