### PR TITLE
Handle promise rejections in mailer calls across controllers

### DIFF
--- a/src/event/controller.js
+++ b/src/event/controller.js
@@ -133,7 +133,7 @@ class EventController extends Controller {
                 continue;
             }
 
-            await mailer.sendEventInvitation(
+            mailer.sendEventInvitation(
                 participant.user.email,
                 {
                     userFullName: participant.user.fullName,
@@ -144,7 +144,7 @@ class EventController extends Controller {
                     startAt: event.startAt,
                     endAt: event.endAt
                 }
-            );
+            ).catch(e => console.error(e));
         }
     }
 
@@ -171,7 +171,7 @@ class EventController extends Controller {
             event = await this.model.getEntityById(event.id);
             await event.prepareRelationFields();
 
-            await this._notifyParticipants(event);
+            this._notifyParticipants(event).catch(e => console.error(e));
 
             return res.status(201).json({
                 data: event.toJSON(),
@@ -202,7 +202,7 @@ class EventController extends Controller {
             event = await this.model.getEntityById(event.id);
             await event.prepareRelationFields();
 
-            await this._notifyParticipants(event);
+            this._notifyParticipants(event).catch(e => console.error(e));
 
             return this._returnResponse(res, 200, {
                 data: event.toJSON()

--- a/src/user/model.js
+++ b/src/user/model.js
@@ -53,7 +53,7 @@ class UserModel extends Model {
     /**
      * @param {Object} data
      * @param {string} expiresIn
-     * @return {string}
+     * @return {Promise<string>}
      */
     async createToken(data, expiresIn = '30d') {
         return jwt.sign(


### PR DESCRIPTION
Replaced `await` with direct calls to mailer functions and added `.catch` blocks to log errors. Updated method return types where appropriate and streamlined the handling of participants in calendar and event controllers for improved error resilience.