### PR TITLE
Add task scheduler and notification for upcoming events

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,14 @@ Full list of commands:
 
 Answers to other questions can be found in the official [db-migrate](https://db-migrate.readthedocs.io/en/latest/) documentation.
 
+## Task Scheduler
 
+Our service can process tasks in the background. Currently, we use it to send email notifications about upcoming events.
+Scheduler are possible on such environments: `dev`, `test`, and `prod`.
+To start the service, you need to run the command.
+```bash
+   npm run scheduler:<env>
+   ```
 
 ## Docker
 Environment variables are taken from `.env.development` file. You can start containers with the command:

--- a/db/migrations/20250319211347-add-notify-before-to-events.js
+++ b/db/migrations/20250319211347-add-notify-before-to-events.js
@@ -1,0 +1,53 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+var fs = require('fs');
+var path = require('path');
+var Promise;
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+  Promise = options.Promise;
+};
+
+exports.up = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20250319211347-add-notify-before-to-events-up.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports.down = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20250319211347-add-notify-before-to-events-down.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports._meta = {
+  "version": 1
+};

--- a/db/migrations/sqls/20250319211347-add-notify-before-to-events-down.sql
+++ b/db/migrations/sqls/20250319211347-add-notify-before-to-events-down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `events` DROP COLUMN `notifyBeforeMinutes`;

--- a/db/migrations/sqls/20250319211347-add-notify-before-to-events-up.sql
+++ b/db/migrations/sqls/20250319211347-add-notify-before-to-events-up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `events` ADD `notifyBeforeMinutes` INT(10) UNSIGNED DEFAULT 10 NOT NULL;

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1092,6 +1092,7 @@
           "category": { "type": "string", "enum": ["work", "home", "hobby"], "example": "work" },
           "type": { "type": "string", "enum": ["meeting", "reminder", "task"], "example": "meeting" },
           "color": {"type": "string", "example": "#F4511E" },
+          "notifyBeforeMinutes": { "type": "integer", "enum": ["10", "30", "60", "1440"], "example": "30" },
           "startAt": { "type": "string", "format": "date-time", "example": "2023-03-09 14:00:00" },
           "endAt": { "type": "string", "format": "date-time", "example": "2023-03-09 15:00:00" },
           "creationByUserId": {"type": "integer", "example": "1"},
@@ -1134,6 +1135,7 @@
           "description": { "type": "string", "example": "Discussion of requirements, business logic, clarification of team composition" },
           "category": { "type": "string", "enum": ["work", "home", "hobby"], "example": "work" },
           "type": { "type": "string", "enum": ["meeting", "reminder", "task"], "example": "meeting" },
+          "notifyBeforeMinutes": { "type": "integer", "enum": ["10", "30", "60", "1440"], "example": "30" },
           "startAt": { "type": "string", "format": "date-time", "example": "2023-03-09 14:00:00" },
           "endAt": { "type": "string", "format": "date-time", "example": "2023-03-09 15:00:00" },
           "participants": {
@@ -1154,6 +1156,7 @@
           "description": { "type": "string", "example": "Creating user flow for authorisation" },
           "category": { "type": "string", "enum": ["work", "home", "hobby"], "example": "work" },
           "type": { "type": "string", "enum": ["meeting", "reminder", "task"], "example": "task" },
+          "notifyBeforeMinutes": { "type": "integer", "enum": ["10", "30", "60", "1440"], "example": "30" },
           "startAt": { "type": "string", "format": "date-time", "example": "2023-03-11 10:00:00" },
           "endAt": { "type": "string", "format": "date-time", "example": "2023-03-11 13:00:00" },
           "participants": {
@@ -1178,6 +1181,7 @@
               "description": { "type": "string", "example": "Creating user flow for authorisation" },
               "category": { "type": "string", "enum": ["work", "home", "hobby"], "example": "work" },
               "type": { "type": "string", "enum": ["meeting", "reminder", "task"], "example": "task" },
+              "notifyBeforeMinutes": { "type": "integer", "enum": ["10", "30", "60", "1440"], "example": "30" },
               "startAt": { "type": "string", "format": "date-time", "example": "2023-03-11 10:00:00" },
               "endAt": { "type": "string", "format": "date-time", "example": "2023-03-11 13:00:00" },
               "creationByUserId": {"type": "integer", "example": "1"},

--- a/mailer/eventUpcoming.html
+++ b/mailer/eventUpcoming.html
@@ -1,0 +1,188 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <title>Join Event</title>
+    <style>
+        /* Import font Inter */
+        @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
+
+        /* Reset default styles */
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            line-height: 1.6;
+            color: #1f2a44;
+            background-color: #f4f4f5;
+        }
+
+        .container {
+            max-width: 600px;
+            margin: 40px auto;
+            padding: 24px;
+            background-color: #ffffff;
+            border-radius: 8px;
+            box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
+            border: 1px solid #e4e4e7;
+        }
+
+        .header {
+            padding-bottom: 16px;
+            text-align: center;
+            border-bottom: 1px solid #e4e4e7;
+        }
+
+        .header h1 {
+            font-size: 24px;
+            font-weight: 600;
+            color: #18181b;
+        }
+
+        .content {
+            padding: 24px 0;
+            text-align: center;
+        }
+
+        .greeting {
+            font-size: 16px;
+            font-weight: 500;
+            margin-bottom: 16px;
+            color: #27272a;
+        }
+
+        .message {
+            font-size: 14px;
+            margin-bottom: 24px;
+            color: #52525b;
+        }
+
+        .event-details {
+            margin-bottom: 24px;
+            padding: 2rem 5rem;
+            background-color: #f9fafb;
+            border-radius: 6px;
+            text-align: left;
+        }
+
+        .event-details p {
+            font-size: 14px;
+            color: #52525b;
+            margin-bottom: 8px;
+            text-align: left;
+        }
+
+        .one-row {
+            display: flex;
+            flex-wrap: wrap;
+            justify-content: space-between;
+            width: 100%;
+            gap: 10px;
+            margin: 0;
+        }
+
+        .one-row code {
+            display: flex;
+            flex-wrap: wrap;
+            width: 100%;
+            gap: 10px;
+        }
+
+        .one-row span {
+            flex: 1 0 auto;
+            white-space: nowrap;
+            text-align: start;
+            min-width: 0;
+        }
+
+        .button {
+            display: inline-block;
+            padding: 10px 20px;
+            background-color: #18181b;
+            color: #ffffff;
+            text-decoration: none;
+            border-radius: 6px;
+            font-size: 14px;
+            font-weight: 500;
+            transition: background-color 0.2s ease;
+            min-width: 8rem;
+        }
+
+        .button:hover {
+            background-color: #27272a;
+        }
+
+        .footer {
+            padding-top: 16px;
+            text-align: center;
+            font-size: 12px;
+            color: #71717a;
+            border-top: 1px solid #e4e4e7;
+        }
+
+        .footer a {
+            color: #71717a;
+            text-decoration: none;
+        }
+
+        .footer a:hover {
+            text-decoration: underline;
+        }
+
+        @media (max-width: 600px) {
+            .container {
+                margin: 16px;
+                padding: 16px;
+            }
+
+            .header h1 {
+                font-size: 20px;
+            }
+
+            .button {
+                display: block;
+                text-align: center;
+            }
+
+            .event-details {
+                padding: 0.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="header">
+            <h1>Event '<%= title %>'</h1>
+        </div>
+        <div class="content">
+            <p class="greeting">Hi, <%= userFullName %>!</p>
+            <p class="message">
+                You have an upcoming event
+            </p>
+            <div class="event-details">
+                <p><strong><%= title %></strong></p>
+                <p><i><time datetime="<%= startAt %>"><%= date %></time></i></p>
+                <p><%= description %></p>
+                <p class="one-row">
+                    <code>
+                        <span><%= category %></span>
+                        <span><%= type %></span>
+                        <span><%= calendar %></span>
+                    </code>
+                </p>
+            </div>
+        </div>
+        <div class="footer">
+            <p>If you didn’t expect this invitation, you can safely ignore this email.</p>
+            <p>© 2025 <a href="http://localhost:3000/">Calendula</a>. All rights reserved.</p>
+        </div>
+    </div>
+</body>
+</html>

--- a/mailer/service.js
+++ b/mailer/service.js
@@ -2,7 +2,6 @@ import nodemailer from 'nodemailer';
 import ejs from 'ejs';
 import * as path from "path";
 import { fileURLToPath } from 'url';
-import { format, parse } from 'date-fns';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
@@ -97,17 +96,17 @@ export async function sendCalendarInvitation(email, data) {
 }
 
 /**
- * @param {string} startAt
- * @param {string} endAt
- * @return {string}
+ * @param {string} email
+ * @param {Object} data
+ * @return {Promise<void>}
  */
-function formatEventDate(startAt, endAt) {
-    const startDate = parse(startAt, "yyyy-MM-dd HH:mm:ss", new Date());
-    const endDate = parse(endAt, "yyyy-MM-dd HH:mm:ss", new Date());
-    const formattedStartDate = format(startDate, "EEEE, MMMM d HH:mm");
-    const formattedEndTime = format(startDate, "EEEE, MMMM d_HH:mm").split('_')[1];
-
-    return `${formattedStartDate} - ${formattedEndTime}`;
+export async function sendEventInvitation(email, data) {
+    await send(
+        email,
+        `Join Event '${data.title}'`,
+        'eventInvitation.html',
+        data
+    );
 }
 
 /**
@@ -115,13 +114,11 @@ function formatEventDate(startAt, endAt) {
  * @param {Object} data
  * @return {Promise<void>}
  */
-export async function sendEventInvitation(email, data) {
-    data.date = formatEventDate(data.startAt, data.endAt);
-
+export async function sendNotifyAboutUpcomingEvent(email, data) {
     await send(
         email,
-        `Join Event '${data.title}'`,
-        'eventInvitation.html',
+        `Notification: ${data.title} @ ${data.date}`,
+        'eventUpcoming.html',
         data
     );
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "jsonwebtoken": "^9.0.2",
         "multer": "^1.4.5-lts.1",
         "mysql2": "^3.10.1",
+        "node-cron": "^3.0.3",
         "nodemailer": "^6.9.15",
         "nodemon": "^3.1.7",
         "playwright": "^1.51.0",
@@ -1615,6 +1616,27 @@
       "license": "MIT",
       "engines": {
         "node": "^18 || ^20 || >= 21"
+      }
+    },
+    "node_modules/node-cron": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/node-cron/-/node-cron-3.0.3.tgz",
+      "integrity": "sha512-dOal67//nohNgYWb+nWmg5dkFdIwDm8EpeGYMekPMrngV3637lqnX0lbUcCtgibHTz6SEz7DAIjKvKDFYCnO1A==",
+      "license": "ISC",
+      "dependencies": {
+        "uuid": "8.3.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/node-cron/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/node-fs": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,10 @@
     "test": "PLAYWRIGHT_HTML_REPORT=\"playwright-report/$(date +%Y-%m-%d_%H-%M-%S)\" npx playwright test tests/api/*.test.js",
     "test:report": "npm run test --debug; npx playwright show-report",
 
+    "scheduler": "node --env-file=.env ./src/services/scheduler/scheduler-service.js",
+    "scheduler:dev": "node --env-file=.env.development ./src/services/scheduler/scheduler-service.js",
+    "scheduler:test": "node --env-file=.env.test ./src/services/scheduler/scheduler-service.js",
+
     "test:seed:users": "PLAYWRIGHT_HTML_REPORT=\"playwright-report/$(date +%Y-%m-%d_%H-%M-%S)\" npx playwright test --workers=1 tests/fake-data/fake.users.test.js",
     "test:seed:calendars": "PLAYWRIGHT_HTML_REPORT=\"playwright-report/$(date +%Y-%m-%d_%H-%M-%S)\" npx playwright test --workers=1 tests/fake-data/fake.calendars.test.js",
     "test:seed:events": "PLAYWRIGHT_HTML_REPORT=\"playwright-report/$(date +%Y-%m-%d_%H-%M-%S)\" npx playwright test --workers=1 tests/fake-data/fake.events.test.js",
@@ -40,6 +44,7 @@
     "jsonwebtoken": "^9.0.2",
     "multer": "^1.4.5-lts.1",
     "mysql2": "^3.10.1",
+    "node-cron": "^3.0.3",
     "nodemailer": "^6.9.15",
     "nodemon": "^3.1.7",
     "playwright": "^1.51.0",

--- a/src/event/controller.js
+++ b/src/event/controller.js
@@ -33,6 +33,10 @@ class EventController extends Controller {
                     .notEmpty().withMessage('Please provide a type.')
                     .isIn(['meeting', 'reminder', 'task']).withMessage('Types: meeting, reminder, task.'),
 
+                body('notifyBeforeMinutes')
+                    .optional()
+                    .isIn([10, 30, 60, 1440]).withMessage('Notify before minutes should be 10, 30, 60, or 1440 minutes.'),
+
                 body('startAt')
                     .notEmpty().withMessage('Please provide a start date and time.')
                     .custom((value, {req}) => {
@@ -75,7 +79,7 @@ class EventController extends Controller {
                 .matches(/^#[0-9A-Fa-f]{6}$/).withMessage('Color must be in the format #RRGGBB.'),
         ];
 
-        const allowedFields = ['title', 'description', 'category', 'type', 'startAt', 'endAt', 'calendarId'];
+        const allowedFields = ['title', 'description', 'category', 'type', 'startAt', 'endAt', 'calendarId', 'notifyBeforeMinutes'];
 
         this._accessPolicies.user
             .setCreate(allowedFields)
@@ -144,6 +148,7 @@ class EventController extends Controller {
                     type: event.type,
                     startAt: event.startAt,
                     endAt: event.endAt,
+                    date: event.getFormattedEventDate(),
                     creator: event.creator.fullName,
                     calendar: event.calendar.title,
                 }

--- a/src/event/entity.js
+++ b/src/event/entity.js
@@ -1,6 +1,7 @@
 import Entity from "../entity.js";
 import UserModel from "../user/model.js";
 import CalendarModel from "../calendar/model.js";
+import {format, isSameDay, parse} from "date-fns";
 
 class EventEntity extends Entity {
     /**
@@ -27,6 +28,38 @@ class EventEntity extends Entity {
 
     async getParticipants() {
         return this._model.getParticipantsByEventId(this.id)
+    }
+
+    /**
+     * Formats the event date range into a human-readable string based on the start and end date-times.
+     *
+     * @return {string} A formatted string representing the event's date range.
+     *                  The format varies depending on whether the event spans a single day, multiple days,
+     *                  full days, or partial days.
+     */
+    getFormattedEventDate() {
+        const startDate = parse(this.startAt, 'yyyy-MM-dd HH:mm:ss', new Date());
+        const endDate = parse(this.endAt, 'yyyy-MM-dd HH:mm:ss', new Date());
+
+        // Якщо обидві дати співпадають (на весь день, 00:00 до 23:59)
+        if (isSameDay(startDate, endDate) && format(startDate, 'HH:mm:ss') === '00:00:00' && format(endDate, 'HH:mm:ss') === '23:59:59') {
+            return format(startDate, 'EEE MMM d, yyyy');
+        }
+
+        // Якщо обидві дати в один день, але час не на весь день
+        if (isSameDay(startDate, endDate)) {
+            const day = format(startDate, 'EEE MMM d, yyyy');
+            const timeRange = `${format(startDate, 'HH:mm')} - ${format(endDate, 'HH:mm')}`;
+            return `${day} ${timeRange}`;
+        }
+
+        // Якщо дати охоплюють кілька днів і час на весь день
+        if (format(startDate, 'HH:mm:ss') === '00:00:00' && format(endDate, 'HH:mm:ss') === '23:59:59') {
+            return `${format(startDate, 'MMM d')} - ${format(endDate, 'MMM d, yyyy')}`;
+        }
+
+        // Якщо дати охоплюють кілька днів і час не на весь день
+        return `${format(startDate, 'EEE MMM d HH:mm')} - ${format(endDate, 'EEE MMM d HH:mm, yyyy')}`;
     }
 }
 

--- a/src/services/scheduler/scheduler-service.js
+++ b/src/services/scheduler/scheduler-service.js
@@ -1,0 +1,10 @@
+import cron from 'node-cron';
+import { notifyUpcomingEventTask } from './tasks/notify-upcoming-event-task.js';
+
+cron.schedule('* * * * *', async () => {
+    console.group('Run scheduler: * * * * * (every minute)');
+
+    await notifyUpcomingEventTask();
+
+    console.groupEnd();
+});

--- a/src/services/scheduler/tasks/notify-upcoming-event-task.js
+++ b/src/services/scheduler/tasks/notify-upcoming-event-task.js
@@ -1,0 +1,36 @@
+import EventModel from '../../../event/model.js';
+import * as mailer from "../../../../mailer/service.js";
+
+
+export async function notifyUpcomingEventTask() {
+    console.group(
+        'Notify upcoming event',' - ', new Date(new Date().getTime() + 2 * 60 * 60000).toISOString().slice(0, 19).replace('T', ' '));
+
+    const events = await new EventModel().getEventsToNotify();
+
+    for (const event of events) {
+    console.info(`Event: [${event.id}] ${event.title} ${event.getFormattedEventDate()}`);
+
+    console.group();
+    for (const participant of event.participants) {
+        console.info(`Participant: [${participant.userId}] ${participant.user.fullName} ${participant.attendanceStatus}`);
+            if (['yes', 'maybe'].includes(participant.attendanceStatus)) {
+                await mailer.sendNotifyAboutUpcomingEvent(
+                    participant.user.email, {
+                        userFullName: participant.user.fullName,
+                        title: event.title,
+                        description: event.title,
+                        type: event.type.charAt(0).toUpperCase() + event.type.slice(1),
+                        category: event.category.charAt(0).toUpperCase() + event.category.slice(1),
+                        startAt: event.startAt,
+                        calendar: event.calendar.title,
+                        date: event.getFormattedEventDate(),
+                    }
+                )
+            }
+        }
+    }
+    console.groupEnd();
+
+    console.groupEnd();
+}

--- a/tests/fake-data/helpers/fake.events.helpers.js
+++ b/tests/fake-data/helpers/fake.events.helpers.js
@@ -5,10 +5,10 @@ import { generateDescription, generateTitle } from "./general.fake.helpers.js";
 /* Must be 7 days from Monday to Sunday inclusive */
 export const DEMO_DATES = {
     year: 2025,
-    monthIndex: 3,
+    monthIndex: 2,
     date: {
-        start: 7,
-        end: 13
+        start: 17,
+        end: 23
     }
 };
 export const EVENT_ATTENDANCE_STATUSES = ['yes', 'no', 'maybe'];


### PR DESCRIPTION
Introduced a task scheduler using `node-cron` to handle background tasks, such as notifying users about upcoming events. Added a `notifyBeforeMinutes` field to the `events` table and backend logic for sending event notifications via email. Updated documentation, API validation, and included a new email template for notifications.