### PR TITLE
Add email verification check before password reset

### DIFF
--- a/src/auth/controller.js
+++ b/src/auth/controller.js
@@ -201,6 +201,13 @@ class AuthController extends UserController {
                 return this._returnNotFound(res);
             }
 
+            if (!user.isVerified) {
+                return this._returnResponse(
+                    res, 400, {},
+                    "Please confirm your email"
+                );
+            }
+
             user.passwordResetToken = await this.model.createToken(
                 { userEmail: user.email },
                 '1d'
@@ -249,6 +256,13 @@ class AuthController extends UserController {
 
                 if (!user) {
                     return this._returnNotFound(res);
+                }
+
+                if (!user.isVerified) {
+                    return this._returnResponse(
+                        res, 400, {},
+                        "Please confirm your email"
+                    );
                 }
 
                 user.password = await this.model.createPassword(req.body.password);


### PR DESCRIPTION
Ensure users can only reset their password if their email is verified. This prevents unverified accounts from accessing password reset functionality. Added the check in both token generation and password reset endpoints.