### PR TITLE
Enable toggle for database query logging via env variable

### DIFF
--- a/.env.development.example
+++ b/.env.development.example
@@ -5,6 +5,7 @@ DATABASE_PORT=3306
 DATABASE_USER=root
 DATABASE_PASSWORD=root
 DATABASE_NAME=Calendula
+DATABASE_LOGS=false
 
 # https://ethereal.email/
 ETHEREAL_MAILER_LOGIN=ricky43@ethereal.email

--- a/.env.test.example
+++ b/.env.test.example
@@ -5,6 +5,7 @@ DATABASE_PORT=3306
 DATABASE_USER=root
 DATABASE_PASSWORD=root
 DATABASE_NAME=Calendula_Test
+DATABASE_LOGS=false
 
 # https://ethereal.email/
 ETHEREAL_MAILER_LOGIN=ricky43@ethereal.email

--- a/src/db.js
+++ b/src/db.js
@@ -32,12 +32,14 @@ const connection = mysql.createPool({
 
 const originalQuery = connection.query;
 connection.query = async function (...args) {
-    const formattedQuery = args[0]
-        .replace(/\s+/g, ' ')
-        .trim();
-    console.log('Executing SQL:', formattedQuery, args[1] ? '' : '\n');
-    if (args[1]) {
-        console.log('With values:', args[1], '\n');
+    if (process.env.DATABASE_LOGS === 'true') {
+        const formattedQuery = args[0]
+            .replace(/\s+/g, ' ')
+            .trim();
+        console.log('Executing SQL:', formattedQuery, args[1] ? '' : '\n');
+        if (args[1]) {
+            console.log('With values:', args[1], '\n');
+        }
     }
     return originalQuery.apply(this, args);
 };


### PR DESCRIPTION
Added a `DATABASE_LOGS` variable to `.env` example files to control query logging. Updated the database query wrapper to log SQL only when `DATABASE_LOGS` is set to `true`. This improves flexibility and reduces unnecessary console output.