### PR TITLE
Remove redundant prepareRelationFields() calls

### DIFF
--- a/src/calendar/controller.js
+++ b/src/calendar/controller.js
@@ -317,7 +317,6 @@ class CalendarController extends Controller {
                 return this._returnNotFound(res);
             }
 
-            await calendar.prepareRelationFields();
             const participant = calendar.participants.find(p => p.userId === req.user.id);
 
             if (!participant) {

--- a/src/event/controller.js
+++ b/src/event/controller.js
@@ -178,7 +178,6 @@ class EventController extends Controller {
             await this.model.syncEventParticipants(event.id, this._prepareParticipants(req));
 
             event = await this.model.getEntityById(event.id);
-            await event.prepareRelationFields();
 
             this._notifyParticipants(event).catch(e => console.error(e));
 
@@ -209,7 +208,6 @@ class EventController extends Controller {
             await this.model.syncEventParticipants(event.id, this._prepareParticipants(req));
 
             event = await this.model.getEntityById(event.id);
-            await event.prepareRelationFields();
 
             this._notifyParticipants(event).catch(e => console.error(e));
 
@@ -243,7 +241,6 @@ class EventController extends Controller {
                 return this._returnNotFound(res);
             }
 
-            await event.prepareRelationFields();
             const participant = event.participants.find(p => p.userId === req.user.id);
 
             if (!participant) {
@@ -300,7 +297,6 @@ class EventController extends Controller {
             );
         }
 
-        await calendar.prepareRelationFields();
         if (calendar.participants.find(p => p.userId === req?.user.id && ['owner', 'member'].includes(p.role))) {
             req.calendar = calendar;
             return next();


### PR DESCRIPTION
The prepareRelationFields() method was removed where it was unnecessary and redundant. This simplifies the code base and ensures cleaner and more efficient controller logic. All affected functionality remains intact.